### PR TITLE
Configure ReadTheDocs for GitHub repository

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,30 @@
 version: 2
+
+# Build documentation with Sphinx
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: false
+
+# Build all formats (PDF, ePub, HTML)
 formats: all
+
+# Python environment configuration
 python:
   install:
+    # Install documentation dependencies
     - requirements: docs/requirements.txt
-    - path: .
+    # Install the package itself (needed for autodoc to import modules)
+    - method: pip
+      path: .
+      extra_requirements:
+        - dev
+
+# Build environment
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.12"
+  # Install system dependencies (VTK, HDF5, etc. are available via apt)
+  apt_packages:
+    - libhdf5-dev
+    - libvtk9-dev

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,9 +108,46 @@ conda run -n fluvial-particle pre-commit run --all-files
 ```
 
 ### Building Documentation
+
 ```bash
-conda run -n fluvial-particle sphinx-build docs docs/_build
+# Build HTML documentation locally
+conda run -n fluvial-particle sphinx-build docs docs/_build/html
+
+# Build with auto-rebuild on file changes (development mode)
+conda run -n fluvial-particle sphinx-autobuild docs docs/_build/html
+
+# Clean previous build
+rm -rf docs/_build
 ```
+
+### ReadTheDocs Setup
+
+The project is configured to automatically build documentation on ReadTheDocs from this GitHub repository.
+
+**Configuration files:**
+- `.readthedocs.yml` - ReadTheDocs build configuration
+- `docs/conf.py` - Sphinx configuration
+- `docs/requirements.txt` - Documentation dependencies
+
+**Setting up a new ReadTheDocs project:**
+
+1. Go to https://readthedocs.org/
+2. Log in with your GitHub account
+3. Click "Import a Project"
+4. Select `rmcd-mscb/fluvial-particle` from your GitHub repositories
+5. Configure project settings:
+   - **Name**: fluvial-particle
+   - **Repository URL**: https://github.com/rmcd-mscb/fluvial-particle
+   - **Default branch**: main
+6. The build will automatically use `.readthedocs.yml` configuration
+7. Enable "Build pull requests" in Admin → Advanced Settings for PR previews
+
+**Manual build trigger:**
+- Go to your ReadTheDocs project dashboard
+- Click "Build Version" to manually trigger a documentation build
+
+**Documentation URL:**
+- https://fluvial-particle.readthedocs.io/en/latest/
 
 ### Version Bumping
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,10 +7,21 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path("..").resolve()))
 sys.path.insert(0, str(Path("../..").resolve()))
+sys.path.insert(0, str(Path("../src").resolve()))
 
 project = "Fluvial Particle"
 author = "Richard McDonald"
 copyright = f"{datetime.now().year}, {author}"
+
+# Get version from package
+try:
+    from fluvial_particle import __version__
+
+    version = __version__
+    release = __version__
+except ImportError:
+    version = "0.0.4"
+    release = "0.0.4"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,6 @@
    :maxdepth: 1
    :titlesonly:
 
-   README
    usage
    optionsfile
    example
@@ -17,4 +16,4 @@
    contributing
    Code of Conduct <codeofconduct>
    License <license>
-   Changelog <https://code.usgs.gov/wma/nhgf/fluvparticle/-/blob/main/HISTORY.md>
+   Changelog <https://github.com/rmcd-mscb/fluvial-particle/blob/main/HISTORY.md>

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
-sphinx
-sphinx-click
-sphinx-rtd-theme
-sphinx-autobuild
-myst-parser
-docutils==0.17
+sphinx>=7.0.0
+sphinx-click>=6.0.0
+sphinx-rtd-theme>=2.0.0
+sphinx-autobuild>=2024.4.0
+myst-parser>=4.0.0


### PR DESCRIPTION
## Summary

Reconfigures ReadTheDocs to publish documentation from this GitHub repository instead of the original GitLab repository.

## Changes

### Configuration Updates
- **`.readthedocs.yml`**: Modernized with Python 3.12, system dependencies (libhdf5-dev, libvtk9-dev), and proper package installation with dev extras
- **`docs/requirements.txt`**: Updated to modern dependency versions (Sphinx 7+, myst-parser 4+, etc.)
- **`docs/conf.py`**: Enhanced to automatically extract version from package

### Documentation Fixes
- **`docs/index.rst`**: 
  - Updated Changelog link from GitLab to GitHub
  - Removed non-existent README reference from toctree

### Documentation
- **`CLAUDE.md`**: Added comprehensive ReadTheDocs setup instructions including:
  - Local build commands
  - ReadTheDocs project configuration steps
  - Documentation URL

## Testing

✅ Local documentation build succeeds with **no warnings**:
```bash
conda run -n fluvial-particle sphinx-build docs docs/_build/html
# Output: build succeeded.
```

## Next Steps

After merging:
1. Set up ReadTheDocs project at https://readthedocs.org/
2. Import `rmcd-mscb/fluvial-particle` repository
3. Enable automatic builds
4. Documentation will be available at https://fluvial-particle.readthedocs.io/

## Related Issues

Closes #6

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)